### PR TITLE
fix opacity issue in string options

### DIFF
--- a/tikz.lua
+++ b/tikz.lua
@@ -769,9 +769,9 @@ function export_text(model, obj, matrix)
    local opacity = obj:get("opacity")
    local prepend = nil
    if params.stylesheets then prepend = "ipe opacity " end
-   opacity = string.gsub(opacity, "%%", "") -- strip %
    if opacity ~= "opaque" then
-      string_option(opacity, nil, options, prepend)
+      opacity = string.format("%.2f", tonumber(string.gsub(opacity, "%%", "")) / 100)
+      string_option(opacity, "opacity", options, prepend)
    end
 
    write(indent .. "\\node")
@@ -1200,9 +1200,9 @@ function export_path(shape, mode, matrix, obj)
       local opacity = obj:get("opacity")
       local prepend = nil
       if params.stylesheets then prepend = "ipe opacity " end
-      opacity = string.gsub(opacity, "%%", "") -- strip %
       if opacity ~= "opaque" then
-         string_option(opacity, nil, options, prepend)
+         opacity = string.format("%.2f", tonumber(string.gsub(opacity, "%%", "")) / 100)
+         string_option(opacity, "opacity", options, prepend)
       end
    end
 


### PR DESCRIPTION
This PR addresses a mismatch between the way opacity values are exported to TeX code and the way \filldraw expects to receive those values. Presently, opacity values are exported as their percentage values, e.g. `30`, whereas TikZ expects to receive them in key-value pair format where the opacity is a decimal, e.g. `opacity=0.30`. This issue raised an error when attempting to compile a simple example when `opacity` is not `opaque`.